### PR TITLE
Fix tslib being required to run react-turnstile

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "module": "CommonJS",
-    "importHelpers": true,
     "declaration": true,
     "sourceMap": true,
     "rootDir": "./src",


### PR DESCRIPTION
Currently you also need to install `tslib` to run `react-turnstile`, as `importHelpers` is enabled in tsconfig.json.
This is how the "compiled" version looks like with `importHelpers` enabled:
```js
"use strict";
Object.defineProperty(exports, "__esModule", { value: true });
const tslib_1 = require("tslib");
```

Everything should still work while no longer needing to install tslib