### PR TITLE
Fix entrypoint in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-turnstile",
   "version": "1.0.1",
   "description": "React library for Cloudflare's Turnstile CAPTCHA alternative",
-  "main": "dist/index.cjs",
+  "main": "dist/index.js",
   "scripts": {
     "prepublishOnly": "npm run build",
     "build": "tsc",


### PR DESCRIPTION
Hello,

I updated the package.json to fix the entry point, the file in .cjs isn't build, so the library can't be used by some bundlers.

![image](https://user-images.githubusercontent.com/8138585/194092518-32d9d0a5-be41-4c0a-aac0-2c9eb1aac6b9.png)

Can you release it?

Have a great day,
Maxime