### PR TITLE
Add require syntax support

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "exports": {
     "import": "./dist/index.js",
+    "require": "./dist/index.js",
     "types": "./dist/index.d.ts"
   },
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
For webpack and similar bundlers, it is necessary to support require(module) syntax. This PR adds that and avoids ERR_PACKAGE_PATH_NOT_EXPORTED.