### PR TITLE
Fix Typo on readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ yourself.
 function Component() {
   return (
     <Turnstile
-      executution="execute"
+      execution="execute"
       onLoad={(widgetId, bound) => {
         // before:
         window.turnstile.execute(widgetId);


### PR DESCRIPTION
There was a typo, which showed as an warning in ts that the property does not exist.