### PR TITLE
Fix type on Size

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -220,7 +220,7 @@ export interface TurnstileProps extends TurnstileCallbacks {
   tabIndex?: number;
   responseField?: boolean;
   responseFieldName?: string;
-  size?: "normal" | "invisible" | "compact";
+  size?: "normal" | "flexible" | "compact";
   fixedSize?: boolean;
   retry?: "auto" | "never";
   retryInterval?: number;


### PR DESCRIPTION
As shown in the turnstile docs [here](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#appearance-modes), the values for size do not include invisible. I presume that this was a mistake, and meant to be "flexible"