### PR TITLE
ci: bump nodejs version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: "18"
+          node-version: "22"
 
       - name: Install dependencies
         run: npm i


### PR DESCRIPTION
CI magically succeeded once merged, but I'll still bump the version