### PR TITLE
Initial commit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-turnstile",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-turnstile",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "^18.0.21",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -214,7 +214,7 @@ export interface TurnstileProps extends TurnstileCallbacks {
   tabIndex?: number;
   responseField?: boolean;
   responseFieldName?: string;
-  size?: "normal" | "compact" | "flexible" | "invisible";
+  size?: "normal" | "compact" | "flexible";
   fixedSize?: boolean;
   retry?: "auto" | "never";
   retryInterval?: number;


### PR DESCRIPTION
`invisible` is not a valid type for `size`

See docs here:
https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#widget-size
![Screenshot 2024-10-20 at 9 20 41 PM](https://github.com/user-attachments/assets/354471c5-a6e5-48e6-9ca6-edad858d9ddc)
