### PR TITLE
Add missing size values to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Turnstile takes the following arguments:
 | tabIndex          | number  | -                                                    |
 | responseField     | boolean | controls generation of `<input />` element           |
 | responseFieldName | string  | changes the name of `<input />` element              |
-| size              | string  | one of "normal", "compact", "flexible", invisible    |
+| size              | string  | one of "normal", "compact", "flexible"               |
 | fixedSize         | boolean | fix the size of the `<div />` to reduce layout shift |
 | retry             | string  | one of "auto", "never"                               |
 | retryInterval     | number  | interval of retries in ms                            |

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Turnstile takes the following arguments:
 | tabIndex          | number  | -                                                    |
 | responseField     | boolean | controls generation of `<input />` element           |
 | responseFieldName | string  | changes the name of `<input />` element              |
-| size              | string  | one of "normal", "compact"                           |
+| size              | string  | one of "normal", "compact", "flexible"               |
 | fixedSize         | boolean | fix the size of the `<div />` to reduce layout shift |
 | retry             | string  | one of "auto", "never"                               |
 | retryInterval     | number  | interval of retries in ms                            |

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Turnstile takes the following arguments:
 | tabIndex          | number  | -                                                    |
 | responseField     | boolean | controls generation of `<input />` element           |
 | responseFieldName | string  | changes the name of `<input />` element              |
-| size              | string  | one of "normal", "compact", "flexible"               |
+| size              | string  | one of "normal", "compact", "flexible", invisible    |
 | fixedSize         | boolean | fix the size of the `<div />` to reduce layout shift |
 | retry             | string  | one of "auto", "never"                               |
 | retryInterval     | number  | interval of retries in ms                            |


### PR DESCRIPTION
The size prop takes 4 values: "flexible" | "normal" | "compact" | "invisible"

Flexible and invisible were missing so I added them to the readme.